### PR TITLE
Update OVRPlayerController.cs

### DIFF
--- a/Clautsro/Assets/OVR/Textures/Util/OVRPlayerController.cs
+++ b/Clautsro/Assets/OVR/Textures/Util/OVRPlayerController.cs
@@ -71,7 +71,7 @@ public class OVRPlayerController : MonoBehaviour
 	/// <summary>
 	/// Modifies the strength of gravity.
 	/// </summary>
-	public float GravityModifier = 0.379f;
+	public float GravityModifier = 0.0f;
 
 	private float MoveScale = 1.0f;
 	private Vector3 MoveThrottle = Vector3.zero;


### PR DESCRIPTION
Since the camera is attached to the PlayerController, and this player controller has no physical shape (i.e. currently has no mesh collider or RigidBody associated with it), I changed GravityModifier to 0.0f to keep the camera from falling to the ground. Alternatively, it could be accomplished by creating a mesh collider to represent the user's physical body, give it gravity, but set the camera to the top of the capsule so that the capsule/camera pair falls but stops once the bottom touches the floor.
